### PR TITLE
Radio button for composer vertex toggle not visible when clicked on back button arrow in execution history for composer

### DIFF
--- a/src/scheduler/composer/NotebookJobs.tsx
+++ b/src/scheduler/composer/NotebookJobs.tsx
@@ -104,6 +104,7 @@ const NotebookJobComponent = ({
   const handleBackButton = () => {
     setShowExecutionHistory(false);
     setBackComposerName(composerName);
+    setExecutionPageFlag(true);
   };
 
   return (


### PR DESCRIPTION
Radio button for composer vertex toggle not visible when clicked on back button arrow in execution history for composer issue fixed.