### PR TITLE
Execution history API not working issue fixed

### DIFF
--- a/src/services/Vertex.tsx
+++ b/src/services/Vertex.tsx
@@ -591,7 +591,7 @@ export class VertexServices {
     const serviceURL = 'api/vertex/listNotebookExecutionJobs';
     const formattedResponse: any = await requestAPI(
       serviceURL +
-        `?region_id=${region}&schedule_id=${schedule_id}&start_date=${selected_month}&page_size=100&order_by=createTime desc`
+        `?region_id=${region}&schedule_id=${schedule_id}&start_date=${selected_month}&order_by=createTime desc`
     );
     try {
       let transformDagRunListDataCurrent = [];

--- a/src/services/Vertex.tsx
+++ b/src/services/Vertex.tsx
@@ -591,7 +591,7 @@ export class VertexServices {
     const serviceURL = 'api/vertex/listNotebookExecutionJobs';
     const formattedResponse: any = await requestAPI(
       serviceURL +
-        `?region_id=${region}&schedule_id=${schedule_id}&start_date=${selected_month}`
+        `?region_id=${region}&schedule_id=${schedule_id}&start_date=${selected_month}&page_size=100&order_by=createTime desc`
     );
     try {
       let transformDagRunListDataCurrent = [];


### PR DESCRIPTION
Execution history API not working issue fixed.

Issue ID: http://b/405052459 Execution History page is not displaying any details for vertex jobs