### PR TITLE
On creating a new bucket cloud storage bucket field becomes empty and  error message 'Cloud storage bucket is required' is displayed 

### DIFF
--- a/src/scheduler/vertex/CreateVertexScheduler.tsx
+++ b/src/scheduler/vertex/CreateVertexScheduler.tsx
@@ -818,7 +818,7 @@ const CreateVertexScheduler = ({
         option => option === DEFAULT_CLOUD_STORAGE_BUCKET
       ) || null
     );
-  }, [cloudStorageList]);
+  }, []);
 
   useEffect(() => {
     const machineTypeOptions = machineTypeList.map(item => item.machineType);


### PR DESCRIPTION
On creating a new bucket cloud storage bucket field becomes empty and  error message 'Cloud storage bucket is required' is displayed  issue fixed