### PR TITLE
Create Button is enabled when subnetwork values is not selected for vertex issue fixed

### DIFF
--- a/src/scheduler/vertex/CreateVertexScheduler.tsx
+++ b/src/scheduler/vertex/CreateVertexScheduler.tsx
@@ -637,7 +637,9 @@ const CreateVertexScheduler = ({
           (item.split(':')[0].length === 0 && item.split(':')[1].length > 0)
       ) ||
       (networkSelected === 'networkInThisProject' &&
-        (primaryNetworkSelected === null || subNetworkSelected === null)) ||
+        (primaryNetworkSelected === null ||
+          subNetworkSelected === null ||
+          subNetworkSelected === undefined)) ||
       (networkSelected === 'networkShared' && sharedNetworkSelected === null) ||
       (scheduleMode === 'runSchedule' &&
         internalScheduleMode === 'cronFormat' &&


### PR DESCRIPTION
Create Button is enabled when subnetwork values is not selected for vertex issue fixed