### PR TITLE
Vertex/Composer radio button is disabled on listing screen when navigating from edit schedule page for composer/vertex schedule

### DIFF
--- a/src/scheduler/composer/CreateNotebookScheduler.tsx
+++ b/src/scheduler/composer/CreateNotebookScheduler.tsx
@@ -423,6 +423,7 @@ const CreateNotebookScheduler = ({
       app.shell.activeWidget?.close();
     } else {
       setCreateCompleted(true);
+      setEditMode(false);
     }
   };
 


### PR DESCRIPTION
Vertex/Composer radio button is disabled on listing screen when navigating from edit schedule page for composer/vertex schedule